### PR TITLE
Update sed command to work with MacOS and Linux

### DIFF
--- a/git-backdate
+++ b/git-backdate
@@ -183,7 +183,7 @@ def main() -> None:
 
     # We construct a sed command to change only our commits
     short_commits = [c[:7] for c in commits]
-    sed_command = rf"sed -i -re 's/^pick ({'|'.join(short_commits)})/edit \1/'"
+    sed_command = rf"sed -i.bak -E 's/^pick ({'|'.join(short_commits)})/edit \1/'"
     check_call(
         ["git", "rebase", "-i", commits[0] + "^"],
         env=dict(os.environ, GIT_SEQUENCE_EDITOR=sed_command),


### PR DESCRIPTION
The current sed command only works with the GNU/Linux version of sed. To make it cross platform we make two changes:

1. Change the in-place argument to use [cross platform syntax](https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux)
2. Change the extended regex flag to the [POSIX compatible flag](https://stackoverflow.com/a/6762201/6411120)