### PR TITLE
Increase backward compatibility for type hints/annotations

### DIFF
--- a/git-backdate
+++ b/git-backdate
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Backdate a commit or range of commit to a date or range of dates.
 """
+from __future__ import annotations
 import argparse
 import datetime as dt
 import math
@@ -140,12 +141,14 @@ def main() -> None:
         "commits",
         metavar="COMMITS",
         default="HEAD",
+        type=str,
         help="COMMITS is a commit or range of commits to backdate. If only one commit is given, it will be used as the end of the range.",
     )
     parser.add_argument(
         "dates",
         metavar="DATES",
         default="now",
+        type=str,
         help='DATES is a date or range of dates to backdate to, can use human readable dates. Separate by .., eg "1 week ago..yesterday"',
     )
     parser.add_argument(


### PR DESCRIPTION
I'm running this tool on Ubuntu 22.10. There the default Python version ist still 3.8 and the type hint added in d0f7cdd lead to the following error:
```
Traceback (most recent call last):
  File "/home/user/.local/bin/git-backdate", line 15, in <module>
    def get_commits(commitish: str) -> list[str]:
TypeError: 'type' object is not subscriptable
```

This PR resolves this error and adds compatibility for the Python 3.8 interpreter.