### PR TITLE
Detect OSX to use gdate by default

### DIFF
--- a/git-backdate
+++ b/git-backdate
@@ -12,8 +12,9 @@ import sys
 from pathlib import Path
 from subprocess import CalledProcessError, call, check_call, check_output
 
-DATE_CMD = os.environ.get("GIT_BACKDATE_DATE_CMD", "date")
+DEFAULT_DATE_CMD = "date" if sys.platform != "darwin" else "gdate"
 
+DATE_CMD = os.environ.get("GIT_BACKDATE_DATE_CMD", DEFAULT_DATE_CMD)
 
 def call_command(args, check=True, **kwargs):
     logger = logging.getLogger("call_command")


### PR DESCRIPTION
Hey,

thanks for the tool, allowing to hide my programming benders from my collaborators.

If for some reason you don't want this change, just close the MR, I'm just too lazy to answer the question how to fix this over and over again.